### PR TITLE
Filter empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.DS_Store
+.idea

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ exports.register = function(server, options, next) {
   let settings = Hoek.clone(options);
   settings = Hoek.applyToDefaults(defaults, settings);
   const ignoreRules = [];
-  const filter = data => ignoreRules.some(f => f(data));
+  const filter = data => !ignoreRules.some(f => f(data));
 
   if (settings.ignore &&
       Array.isArray(settings.ignore) &&
@@ -48,6 +48,7 @@ exports.register = function(server, options, next) {
       if (data.userAgent) {
         data.browser = userAgentLib.parse(data.userAgent).toString();
       }
+
       if (filter(data)) {
         request.server.log(tags, {
           data

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,6 +25,14 @@ exports.register = function(server, options, next) {
     });
   }
 
+  if (settings.ignoreIfEmpty &&
+    Array.isArray(settings.ignoreIfEmpty) &&
+  settings.ignoreIfEmpty.length) {
+    ignoreRules.push(
+      value => settings.ignoreIfEmpty.some(
+        key => typeof value[key] === 'undefined'
+      )
+    );
   }
 
   server.route({

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,27 +11,20 @@ const defaults = {
 exports.register = function(server, options, next) {
   let settings = Hoek.clone(options);
   settings = Hoek.applyToDefaults(defaults, settings);
-  let filter = () => true;
+  const ignoreRules = [];
+  const filter = data => ignoreRules.some(f => f(data));
 
   if (settings.ignore &&
       Array.isArray(settings.ignore) &&
       settings.ignore.length) {
-    filter = data => {
-      let isLoggable = true;
+    settings.ignore.forEach(ignore => {
+      ignoreRules.push(value => Object.keys(ignore).some(key => {
+        const regexp = new RegExp(ignore[key]);
+        return regexp.exec(value[key]) !== null;
+      }));
+    });
+  }
 
-      const checkIgnore = (ignore, value) =>
-        Object.keys(ignore).some(key => {
-          const regexp = new RegExp(ignore[key]);
-
-          return regexp.exec(value[key]) !== null;
-        });
-
-      for (let i = 0, len = settings.ignore.length; i < len && isLoggable; i++) {
-        isLoggable = !checkIgnore(settings.ignore[i], data);
-      }
-
-      return isLoggable;
-    };
   }
 
   server.route({

--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
   },
   "homepage": "https://github.com/firstandthird/hapi-browser-log#readme",
   "devDependencies": {
-    "eslint": "^3.8.1",
-    "eslint-config-firstandthird": "^3.0.2",
-    "eslint-plugin-import": "2.2.0",
+    "eslint": "^4.10.0",
+    "eslint-config-firstandthird": "^4.0.1",
+    "eslint-plugin-import": "^2.8.0",
     "handlebars": "^4.0.5",
     "hapi": "^16.0.2",
     "inert": "^4.0.2",
     "vision": "^4.1.0"
   },
   "dependencies": {
-    "hoek": "^4.1.0",
+    "hoek": "^5.0.1",
     "useragent": "^2.2.1"
   },
   "eslintConfig": {


### PR DESCRIPTION
I see an increasing number of errors that we can't seem to get rid of. They seem to be triggered by extensions or other parties. They usually are stack-less errors or filename-less ones.

With that in mind, I've refactored the filter function to be able to be more extensive and be reused. 

However, I've realized that 404 AJAX errors have no stack and also, no file. 

Unsure of what's the best way to handle these errors with this in mind. I wouldn't like to complicate logic much much further on this since this should likely be simple.

@orthagonal and @jgallen23 any ideas?